### PR TITLE
[feat] 최근 감상한 웹툰 정보 조회

### DIFF
--- a/src/main/java/org/sopt/kakao/controller/WebtoonController.java
+++ b/src/main/java/org/sopt/kakao/controller/WebtoonController.java
@@ -7,6 +7,7 @@ import org.sopt.kakao.service.WebtoonService;
 import org.sopt.kakao.service.dto.WebtoonDayListResponse;
 import org.sopt.kakao.service.dto.WebtoonDayResponse;
 import org.sopt.kakao.service.dto.WebtoonListResponse;
+import org.sopt.kakao.service.dto.WebtoonRecentViewListResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,6 +33,12 @@ public class WebtoonController {
     public ResponseEntity<SuccessResponse> getWebtoonsByDay(@RequestParam final String day) {
         WebtoonDayListResponse webtoons = webtoonService.findWebtoonsByDay(day);
         return ResponseEntity.ok(SuccessResponse.of(webtoons));
+    }
+
+    @GetMapping("webtoons/recent")
+    public ResponseEntity<SuccessResponse> getRecentWebtoons() {
+        WebtoonRecentViewListResponse recentWebtoons = webtoonService.getRecentWebtoons();
+        return ResponseEntity.ok(SuccessResponse.of(recentWebtoons));
     }
 
 }

--- a/src/main/java/org/sopt/kakao/repository/WebtoonRepository.java
+++ b/src/main/java/org/sopt/kakao/repository/WebtoonRepository.java
@@ -13,4 +13,6 @@ public interface WebtoonRepository extends JpaRepository<Webtoon, Long> {
     List<Webtoon> findAllByTitle(String title);
 
     List<Webtoon> findByDay(Day day);
+
+    List<Webtoon> findTop5ByOrderByIdDesc();
 }

--- a/src/main/java/org/sopt/kakao/service/WebtoonService.java
+++ b/src/main/java/org/sopt/kakao/service/WebtoonService.java
@@ -13,10 +13,7 @@ import org.sopt.kakao.domain.Thumbnail;
 import org.sopt.kakao.domain.Webtoon;
 import org.sopt.kakao.repository.ThumbnailRepository;
 import org.sopt.kakao.repository.WebtoonRepository;
-import org.sopt.kakao.service.dto.WebtoonDayListResponse;
-import org.sopt.kakao.service.dto.WebtoonDayResponse;
-import org.sopt.kakao.service.dto.WebtoonListResponse;
-import org.sopt.kakao.service.dto.WebtoonSearchResponse;
+import org.sopt.kakao.service.dto.*;
 import org.springframework.stereotype.Service;
 
 import static org.sopt.kakao.common.dto.ErrorMessage.THUMNAIL_NOT_FOUND;
@@ -49,6 +46,20 @@ public class WebtoonService {
     private Optional<Thumbnail> findThumbnail(final Webtoon webtoon) {
         List<Thumbnail> thumbnail = thumbnailRepository.findByWebtoon(webtoon);
         return thumbnail.stream().findFirst();
+    }
+
+    public WebtoonRecentViewListResponse getRecentWebtoons() {
+        List<Webtoon> recentWebtoons = webtoonRepository.findTop5ByOrderByIdDesc();
+        List<WebtoonRecentViewResponse> webtoonResponses = recentWebtoons.stream()
+                .map(webtoon -> WebtoonRecentViewResponse.of(webtoon, findImage(webtoon)))
+                .toList();
+        return new WebtoonRecentViewListResponse(webtoonResponses);
+    }
+
+
+    private Optional<Thumbnail> findImage(final Webtoon webtoon) {
+        List<Thumbnail> thumbnails = thumbnailRepository.findByWebtoon(webtoon);
+        return thumbnails.stream().reduce((first, second) -> second);
     }
 
 }

--- a/src/main/java/org/sopt/kakao/service/dto/WebtoonRecentViewListResponse.java
+++ b/src/main/java/org/sopt/kakao/service/dto/WebtoonRecentViewListResponse.java
@@ -1,0 +1,7 @@
+package org.sopt.kakao.service.dto;
+
+import java.util.List;
+
+public record WebtoonRecentViewListResponse(
+        List<WebtoonRecentViewResponse> webtoons
+) {}

--- a/src/main/java/org/sopt/kakao/service/dto/WebtoonRecentViewResponse.java
+++ b/src/main/java/org/sopt/kakao/service/dto/WebtoonRecentViewResponse.java
@@ -1,0 +1,26 @@
+package org.sopt.kakao.service.dto;
+
+import jakarta.annotation.Nullable;
+import org.sopt.kakao.domain.Thumbnail;
+import org.sopt.kakao.domain.Webtoon;
+
+import java.util.Optional;
+
+public record WebtoonRecentViewResponse(
+        String title,
+        String author,
+        @Nullable
+        String image,
+        String genre,
+        String promotion) {
+    public static WebtoonRecentViewResponse of(Webtoon webtoon, Optional<Thumbnail> thumbnail){
+        return new WebtoonRecentViewResponse(
+                webtoon.getTitle(),
+                webtoon.getAuthor(),
+                thumbnail.map(Thumbnail::getImage).orElse(null),
+                webtoon.getGenre().getDescription(),
+                webtoon.getPromotion()
+        );
+    }
+
+}


### PR DESCRIPTION
## Related Issue 📌
close #13 

## Description ✔️
- 최근 감상한 작품 5개를 고정해서 보냅니다

## To Reviewers
이미지 중 2번째 이미지가 조회되는 것을 확인했습니다.
`findLast()`  메서드를 활용해 구현했으나 오류가 나서 찾아보니 Java의 `Stream` API가  `findFirst()`를 제공하지만, `findLast()`는 제공하지 않는다는 점을 발견했습니다. 따라서 해당 메서드가 아닌 다른 방식을 통해 구현했는데 확인 부탁드립니다 !

```java

  private Optional<Thumbnail> findImage(final Webtoon webtoon) {
        List<Thumbnail> thumbnails = thumbnailRepository.findByWebtoon(webtoon);
        return thumbnails.stream().reduce((first, second) -> second);
    }
```

![image](https://github.com/user-attachments/assets/a2373b12-3f6d-4a2d-b560-b6ce9dd29e8a)

